### PR TITLE
Added SSM compatibility

### DIFF
--- a/assets/duplicate_entry.js
+++ b/assets/duplicate_entry.js
@@ -47,5 +47,8 @@ var DuplicateEntry = {
 }
 
 jQuery(document).ready(function() {
-	DuplicateEntry.init();
+	// do not show when in Subsection Manager
+	if (!$('#body').hasClass('subsection')) {
+		DuplicateEntry.init();
+	}
 });

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -62,6 +62,14 @@
 				
 				$page->addScriptToHead(URL . '/extensions/duplicate_entry/assets/duplicate_entry.js', 10001);
 				
+				// add particular css for SSM
+				Administration::instance()->Page->addElementToHead(
+					new XMLElement(
+						'style',
+						"body.inline.subsection #duplicate-entry { display: none; visibility: collapse }",
+						array('type' => 'text/css')
+					), time()+101
+				);
 			}
 		}
 	}


### PR DESCRIPTION
There you go mate.

I have added 2 fix:

1 - Added the same CSS fixed that I used in save_and_return (i.e. https://github.com/Solutions-Nitriques/save_and_return/blob/master/extension.driver.php#L213 vs. https://github.com/DeuxHuitHuit/duplicate_entry/blob/master/extension.driver.php#L66)
2 - Since your extensions uses JS to create the button, I simply added a simple if clause to check if we are in the SSM (i.e. https://github.com/DeuxHuitHuit/duplicate_entry/blob/master/assets/duplicate_entry.js#L51)

You are free to use both or only one.
