### PR TITLE
Add option to clear fields on save using config

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -9,5 +9,17 @@
 
 When viewing an entry's "edit" form you will see a "Save as New" button. Submitting the form using this button will save changes to a brand new entry. If you have two sections with identical schemas (field names and types are compared) then a dropdown will be displayed beside the Save as New button allowing you to save a copy of the entry into the other section.
 
+### Clearing Fields
+
+For each section you can list fields which need to be cleared (blank value) on save; the below is a template you can use to add settings.
+
+	###### DUPLICATE_ENTRY ######
+	'duplicate_entry' => array(
+		'section-name' =>  array(
+			"field-name-1",
+			"field-name-2",
+		)
+	),
+
 ## Todo
 * Fix bug whereby validation errors render the form back in "new" mode (potentially unfixable)

--- a/assets/duplicate_entry.js
+++ b/assets/duplicate_entry.js
@@ -10,10 +10,10 @@
 	var DuplicateEntry = {
 		
 		init: function() {
-			var actions = jQuery('div.actions');
+			var actions = $('div.actions');
 			var save_button = actions.find('input[type="submit"]');
 			
-			var form = jQuery('form');
+			var form = $('form');
 			var form_action = form.attr('action');
 			
 			var current_section = Symphony.Context.get('duplicate-entry')['current-section'];
@@ -33,13 +33,29 @@
 			
 			save_button.after('<span id="duplicate-entry" style="display:block;float:right;"></span>');
 			
-			jQuery('#duplicate-entry')
+			$('#duplicate-entry')
 			.append('<span style="float:right;display:block;width:30px;text-align:center;margin-right:-10px;line-height:2;color:darkGray;">' + Symphony.Language.get("or") + '</span>')
 			.append('<input type="submit" value="' + Symphony.Language.get("Save as New") + '" id="duplicate-button" name="action[save-duplicate]"/>')
 			.append(sections);
 			
-			jQuery('#duplicate-button').click(function() {
-				jQuery(this).attr('name', 'action[save]');
+			$('#duplicate-button').click(function() {
+
+				var clearFields = Symphony.Context.get('duplicate-entry')['clear-fields'];
+
+				for (var i = clearFields.length - 1; i >= 0; i--) {
+
+					$element = $('input[name="fields['+clearFields[i]+']"]');
+
+					if ($element.attr('type')=='checkbox'){
+						$element.attr('checked',false);
+					} else {
+						$element.val('');
+
+					}
+				}
+
+
+				$(this).attr('name', 'action[save]');
 				var action = form_action.replace(/edit\/[0-9]+\/(.+)?/, 'new/');
 				if (duplicate_sections != null) {
 					action = form_action.replace(/publish\/([a-zA-Z0-9-_]+)\/(.+)?/, 'publish/' + jQuery('#duplicate-section').val() + '/new/');

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -48,6 +48,19 @@
 				}
 				
 				if (count($duplicate_sections) < 2) $duplicate_sections = NULL;
+
+				$duplicateEntryConfig = Symphony::Configuration()->get('duplicate_entry');
+				$sections = array_keys($duplicateEntryConfig);
+
+				$configOptionToClearFields = array();
+						
+				$thisSection = $page->_context['section_handle'];
+				// Only load on /publish/static-pages/ [this should be a variable]
+				if ( in_array($thisSection , $sections) ){
+
+					$configOptionToClearFields = $duplicateEntryConfig[$thisSection];
+
+				}
 				
 				Administration::instance()->Page->addElementToHead(
 					new XMLElement(
@@ -55,6 +68,7 @@
 						"Symphony.Context.add('duplicate-entry', " . json_encode(array(
 							'current-section' => $callback['context']['section_handle'],
 							'duplicate-sections' => $duplicate_sections,
+							'clear-fields' => $configOptionToClearFields,
 						)) . ");",
 						array('type' => 'text/javascript')
 					), time()

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -15,11 +15,18 @@
 			<name github="nickdunn" symphony="nickdunn">Nick Dunn</name>
 			<website>http://nick-dunn.co.uk</website>
 		</author>
+		<author>
+			<name github="mazedigital" symphony="gunglien">Maze Digital</name>
+			<website>https://maze.digital</website>
+		</author>
 	</authors>
 	<releases>
 		<release version="1.2" date="2010-11-29" min="2.0.6" />
 		<release version="1.2.1" date="2010-11-30" min="2.0.6" max="2.2.5" />
 		<release version="1.3" date="2012-03-08" min="2.3.x" />
 		<release version="1.4" date="2014-07-31" min="2.3.0" max="2.5.x" />
+		<release version="1.5" date="2017-03-15" min="2.3.0" max="2.6.x" >
+			- Add Option to clear fields on Save using config
+		</release>
 	</releases>
 </extension>


### PR DESCRIPTION
At times you might want to make sure that things like publish date is not set to the article which was cloned. So this will remove values before saving - dates would be handled by Symphony. Also supports clearing checkboxes like a publish checkbox to ensure an article is in draft. More details in readme.